### PR TITLE
Download do DB para uso local na darknet, fixes e melhorias minors

### DIFF
--- a/labelling_web_app/scripts/b2.py
+++ b/labelling_web_app/scripts/b2.py
@@ -47,6 +47,9 @@ class B2:
             r = _safe_post(self._url, headers=headers, data=body)
             return r.json()['fileId']
 
+    def __init__(self):
+        self._auth = None
+
     def authorize_account(self, account_id, account_key):
         r = _safe_get('https://api.backblazeb2.com/b2api/v1/b2_authorize_account', auth=(account_id, account_key))
         data = r.json()
@@ -55,7 +58,8 @@ class B2:
                              downloadUrl=data['downloadUrl'], minimumPartSize=data['minimumPartSize'])
 
     def get_download_url(self, file_id):
-        return '{}/b2api/v1/b2_download_file_by_id?fileId={}'.format(self._auth.downloadUrl, file_id)
+        download_url = self._auth and self._auth.downloadUrl or os.environ['B2_DOWNLOAD_URL']
+        return '{}/b2api/v1/b2_download_file_by_id?fileId={}'.format(download_url, file_id)
 
     def get_uploader(self, bucket_id):
         r = _safe_post('{}/b2api/v1/b2_get_upload_url'.format(self._auth.apiUrl),

--- a/labelling_web_app/scripts/download_new_labels.py
+++ b/labelling_web_app/scripts/download_new_labels.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 from collections import defaultdict
 from labelling_web_app.db.connection import Connection
 import labelling_web_app.storage.b2 as b2

--- a/labelling_web_app/scripts/download_new_labels.py
+++ b/labelling_web_app/scripts/download_new_labels.py
@@ -10,7 +10,7 @@ from xml.etree import ElementTree
 def get_new_labels():
     conn = Connection()
     with conn.cursor() as cursor:
-        cursor.execute('DELETE FROM new_labels WHERE id IN (SELECT id FROM new_labels LIMIT 10) RETURNING *')
+        cursor.execute('DELETE FROM new_labels WHERE id IN (SELECT DISTINCT id FROM new_labels LIMIT 10) RETURNING *')
         data = cursor.fetchall()
     conn.commit()
     conn.close()

--- a/labelling_web_app/scripts/update_local_labels.py
+++ b/labelling_web_app/scripts/update_local_labels.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+from collections import defaultdict
+from labelling_web_app.scripts.b2 import B2
+from labelling_web_app.db.connection import Connection
+import os
+from urllib.request import urlretrieve
+
+
+def db_fetch_all_labels():
+    conn = Connection()
+    with conn.cursor() as cursor:
+        cursor.execute('SELECT * FROM labels')
+        data = cursor.fetchall()
+    conn.close()
+    return data
+
+
+def ensure_path(path):
+    os.path.isdir(path) or os.mkdir(path)
+
+
+def parse_args():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('dir', help='Directory where final labels/images should be saved')
+    return parser.parse_args()
+
+
+def main(args):
+    assert(os.path.isdir(args.dir))
+    images_dir = os.path.join(args.dir, 'images')
+    labels_dir = os.path.join(args.dir, 'labels')
+    ensure_path(images_dir)
+    ensure_path(labels_dir)
+    b2 = B2()
+
+    labels = defaultdict(list)
+    for line in db_fetch_all_labels():
+        labels[line[0]].append(line[1:])
+    print('Remote database has {} labels'.format(len(labels)))
+
+    for image_id, boxes in labels.items():
+        if not os.path.isfile(os.path.join(labels_dir, '{}.txt'.format(image_id))):
+            print('Downloading new image {}'.format(image_id))
+            urlretrieve(b2.get_download_url(image_id), os.path.join(images_dir, '{}.png'.format(image_id)))
+            label_file = os.path.join(labels_dir, '{}.txt'.format(image_id))
+            with open(label_file, 'w') as f:
+                f.write('\n'.join(['0 {}'.format(' '.join(map(str, x))) for x in boxes]))
+
+
+if __name__ == '__main__':
+    main(parse_args())

--- a/labelling_web_app/scripts/upload_final_labels.py
+++ b/labelling_web_app/scripts/upload_final_labels.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 from labelling_web_app.db.connection import Connection
 import os
 import sys

--- a/labelling_web_app/scripts/upload_final_labels.py
+++ b/labelling_web_app/scripts/upload_final_labels.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from labelling_web_app.db.connection import Connection
 import os
+import shutil
 import sys
 from xml.etree import ElementTree
 
@@ -47,6 +48,8 @@ def main(args):
             print('Uploading {}'.format(label))
             full_path = os.path.join(dirpath, label)
             upload_label_file(full_path)
+    shutil.rmtree('images')
+    shutil.rmtree('voc-labels')
 
 
 if __name__ == '__main__':

--- a/labelling_web_app/scripts/upload_new_images.py
+++ b/labelling_web_app/scripts/upload_new_images.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 from labelling_web_app.scripts.b2 import B2
 from labelling_web_app.db.connection import Connection
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-click==6.6
+click==6.7
 Flask==0.12
-gevent==1.2.0
+gevent==1.2.1
 greenlet==0.4.11
 gunicorn==19.6.0
 itsdangerous==0.24
-Jinja2==2.8
+Jinja2==2.9.4
 MarkupSafe==0.23
 psycopg2==2.6.2
-Werkzeug==0.11.11
+requests==2.12.5
+Werkzeug==0.11.15

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
 
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['flask', 'gevent', 'gunicorn', 'psycopg2'],
+    install_requires=['flask', 'gevent', 'gunicorn', 'psycopg2', 'requests'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.


### PR DESCRIPTION
Alguns fixes discutidos e melhorias sugeridas, incluindo apagar imagens e labels após upload com sucesso (valeu @erickotsuka , não tinha pensado nisso antes), e o script para download das labels.

Após download, há alguns passos a mais necessários para rodar na darknet, mas deixo para vocês se divertirem (é legal que vocês comecem a fazer esses scriptzinhos de uso diário também, facilitam as coisas). Vocês podem fazer um script para gerar os arquivos que faltam pra darknet e adicionar nesse repositório. É basicamente o que é feito da linha 67 até a 86 em [ThundeRatz/ros_yolo:scripts/labelImg_to_yolo.py](https://github.com/ThundeRatz/ros_yolo2/blob/acc54b89716e58d40e54583e4cd485410fa7b933/scripts/labelImg_to_yolo.py#L67-L86):

1. Dividir as imagens e labels em um grupo de treino e um de validação aleatórios. Busquem usar valores recomendados para a rede (no caso da YOLO, acho que 20% de validação era o usado). Salvar em arquivos as listas de nomes, onde cada linha do arquivo aponta para uma imagem (caminho completo para o png).
2. Gerar um arquivo com o mapeamento de índices para nomes (não é usado de verdade pra treinar a YOLO, mas é necessário para ferramentas de visualização depois com a darknet).
3. Gerar o arquivo `.data`, que possui a descrição geral do dataset e é passado para a darknet para treino. Ele é um arquivo com chaves e valores separados por `=`, com as seguintes chaves:
    1. `classes`: # de classes
    2. `train`: Caminho para arquivo com imagens de treino
    3. `valid`: Caminho para arquivo com imagens de validação
    4. `names`: Caminho para arquivo com mapeamento de nomes
    5. `backup`: Caminho pasta onde serão salvos os snapshots ("backups") da rede

Com tudo pronto, usem a darknet: `./darknet detector train <arquivo .data> <configuração da rede> darknet19_448.conv.23`. O `.data` é o que vocês geraram, a configuração é a que [está no B2](https://f001.backblazeb2.com/b2api/v1/b2_download_file_by_id?fileId=4_z8126b7d060d92d74599e0618_f1021bf36588d327c_d20161223_m010407_c001_v0001032_t0054), que é a tiny-YOLO levemente modificada para rodar com uma única classe, e o `darknet19_448.conv.23` é um arquivo com pesos pré-treinados, que vocês baixam do site da darknet.